### PR TITLE
Gemfile_end記入忘れ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ group :development, :test do
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
   gem 'capistrano3-unicorn'
+end
 
 group :production do
   gem 'unicorn', '5.4.1'


### PR DESCRIPTION
Capistrano導入時、コンフリクト。
解消のため記述変更しました。
その際に、endを削除してしまった。
Gemfile,end記入し解消。