### PR TITLE
カテゴリーmaigrationファイル削除

### DIFF
--- a/db/migrate/20191203064424_category.rb
+++ b/db/migrate/20191203064424_category.rb
@@ -1,5 +1,0 @@
-class Category < ActiveRecord::Migration[5.2]
-  def change
-    drop_table :categories
-  end
-end


### PR DESCRIPTION
誤って作成したmigrationfileを削除。
カテゴリーは使っていないため、削除。