### PR TITLE
ホームボタンを表示

### DIFF
--- a/app/assets/stylesheets/places/_show.scss
+++ b/app/assets/stylesheets/places/_show.scss
@@ -25,6 +25,17 @@
       font-size:50px;
       opacity:0.5;
     }
+    &__botton{
+      margin:10px 0 0 0;
+      &__root{
+        background-color: red;
+        border:0;
+        color:white;
+        font-size:15px;
+        cursor:pointer;
+        padding:10px;
+      }
+    }
   }
 .c-body{
     &__box{     

--- a/app/views/pleces/show.html.haml
+++ b/app/views/pleces/show.html.haml
@@ -3,6 +3,9 @@
     .c-top
       .c-top__title
         = @place.name
+      .c-top__botton
+        = link_to root_path do
+          %button.c-top__botton__root 検索画面へ移動する
     .c-body
       .c-body__box  
       - @place.images.each do |image|   


### PR DESCRIPTION
詳細ページにホームボタンを表示。
以前は、ホームボタンがないため、ユーザーが利用しづらかった。